### PR TITLE
Adding String func so Encoding is a fmt.Stringer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,7 @@ func trySkip(byteData []byte) {
 
 	// skip BOM and detect encoding
 	sr, enc := utfbom.Skip(bytes.NewReader(byteData))
-	var encStr string
-	switch enc {
-	case utfbom.UTF8:
-		encStr = "UTF8"
-	case utfbom.UTF16BigEndian:
-		encStr = "UTF16 big endian"
-	case utfbom.UTF16LittleEndian:
-		encStr = "UTF16 little endian"
-	case utfbom.UTF32BigEndian:
-		encStr = "UTF32 big endian"
-	case utfbom.UTF32LittleEndian:
-		encStr = "UTF32 little endian"
-	default:
-		encStr = "Unknown, no byte-order mark found"
-	}
-	fmt.Println("Detected encoding:", encStr)
+	fmt.Printf("Detected encoding: %s\n", enc)
 	output, err = ioutil.ReadAll(sr)
 	if err != nil {
 		fmt.Println(err)
@@ -74,7 +59,7 @@ ReadAll with BOM detection and skipping [104 101 108 108 111]
 
 Input: [104 101 108 108 111]
 ReadAll with BOM skipping [104 101 108 108 111]
-Detected encoding: Unknown, no byte-order mark found
+Detected encoding: Unknown
 ReadAll with BOM detection and skipping [104 101 108 108 111]
 ```
 

--- a/utfbom.go
+++ b/utfbom.go
@@ -32,6 +32,24 @@ const (
 	UTF32LittleEndian
 )
 
+// String returns a user-friendly string representation of the encoding. Satisfies fmt.Stringer interface.
+func (e Encoding) String() string {
+	switch e {
+	case UTF8:
+		return "UTF8"
+	case UTF16BigEndian:
+		return "UTF16BigEndian"
+	case UTF16LittleEndian:
+		return "UTF16LittleEndian"
+	case UTF32BigEndian:
+		return "UTF32BigEndian"
+	case UTF32LittleEndian:
+		return "UTF32LittleEndian"
+	default:
+		return "Unknown"
+	}
+}
+
 const maxConsecutiveEmptyReads = 100
 
 // Skip creates Reader which automatically detects BOM (Unicode Byte Order Mark) and removes it as necessary.

--- a/utfbom_test.go
+++ b/utfbom_test.go
@@ -231,3 +231,16 @@ func TestReader_ReadEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestEncoding_String(t *testing.T) {
+	for e := Unknown; e <= UTF32LittleEndian; e++ {
+		s := e.String()
+		if s == "" {
+			t.Errorf("no string for %#v", e)
+		}
+	}
+	s := Encoding(999).String()
+	if s != "Unknown" {
+		t.Errorf("wrong string '%s' for invalid encoding", s)
+	}
+}


### PR DESCRIPTION
PTAL @dimchansky 

This helps reduce boilerplate when I want to output which encoding a file is in. I was unsure whether to return a string version of the consts themselves (i.e. `UTF16BigEndian == "UTF16BigEndian"`), or to make them a bit more friendly, like you had in `README.md`. I chose the latter since it's slightly more explanatory in the `Unknown` case.

Signed-off-by: Dave Henderson <David.Henderson@qlik.com>