### PR TITLE
Updating go versions in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.7
-  - tip
+  - '1.10'
+  - '1.11'
 
 # sudo=false makes the build run using a container
 sudo: false


### PR DESCRIPTION
Go 1.7 has been unsupported for a while 😉

Updating TravisCI config to test 1.10 and 1.11, the two currently supported versions.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>