### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 sudo: false
-
+arch:
+  - AMD64
+  - ppc64le
 go:
   - 1.10.x
   - 1.11.x


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.